### PR TITLE
Correct 5.5-cli image name with compatible redis, xdebug versions

### DIFF
--- a/5.5-cli/Dockerfile
+++ b/5.5-cli/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:5.5-fpm
+FROM php:5.5-cli
 MAINTAINER Alterway <iac@alterway.fr>
 
 RUN apt-get update && \
@@ -50,8 +50,8 @@ RUN ln -s /usr/include/x86_64-linux-gnu/gmp.h /usr/include/gmp.h && \
     docker-php-ext-install sockets && \
     pecl install mongo && \
     pecl install memcached-2.2.0 && \
-    pecl install redis && \
-    pecl install xdebug
+    pecl install redis-3.1.0 && \
+    pecl install xdebug-2.5.0
 
 ADD https://blackfire.io/api/v1/releases/probe/php/linux/amd64/55 /tmp/blackfire-probe.tar.gz
 RUN tar zxpf /tmp/blackfire-probe.tar.gz -C /tmp && \


### PR DESCRIPTION
Firstly, thanks alterway for making all these php images available.

Yes, this is an old outdated version of PHP, but we need it to test some legacy applications first before upgrading to a newer version of PHP. 

Basically, if you don't set the php image name correctly, the cli container exposes a port, which can be a bit annoying if you also have a php-5.5-fpm container running separately too.

Additionally, you have to be explicit with the versions of redis and xdebug, because the default latest stable versions aren't compatible with PHP 5.5.